### PR TITLE
Live display

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ for the playlist feature across different platforms***
 ### Install
 
 Github latest [Release](https://github.com/jooapa/signal-jammer/releases/latest)
+Linux version of jammer requires fuse2. Ubuntu 22.02 or newer install `apt
+install libfuse2`.
 
 ### Update existing
 
@@ -179,7 +181,7 @@ dotnet publish -r linux-x64 -c Release /p:PublishSingleFile=true
 
 AppImage requires fuse. To install fuse
 ```
-sudo apt install fuse
+sudo apt install libfuse2
 ```
 
 To install appimagetool

--- a/src/Start.cs
+++ b/src/Start.cs
@@ -1,6 +1,6 @@
 using ManagedBass;
 using Spectre.Console;
-using System;
+/* using System; */
 using System.Runtime.InteropServices;
 
 namespace jammer
@@ -237,6 +237,7 @@ namespace jammer
                 {
                     consoleHeight = Console.WindowHeight;
                     consoleWidth = Console.WindowWidth;
+                    AnsiConsole.Clear();
                     TUI.RehreshCurrentView();
                 }
 

--- a/src/TUI.cs
+++ b/src/TUI.cs
@@ -1,6 +1,6 @@
 using Spectre.Console;
 using jammer;
-using System.ComponentModel.DataAnnotations;
+/* using System.ComponentModel.DataAnnotations; */
 
 static class TUI
 {
@@ -8,7 +8,8 @@ static class TUI
 
     static public void DrawPlayer() {
         try {
-
+            var ansiConsoleSettings = new AnsiConsoleSettings();
+            var ansiConsole = AnsiConsole.Create(ansiConsoleSettings);
             if (Start.playerView == "help" || Start.playerView == "settings")
             {
                 return;
@@ -30,6 +31,7 @@ static class TUI
             if (cls) {
                 if (Start.playerView != "all") {
                     AnsiConsole.Clear();
+                    Debug.dprint("DrawPlayer - clear");
                 }
                 cls = false;
             }
@@ -62,12 +64,16 @@ static class TUI
                 }
             }
             mainTable.AddRow(UIComponent_Time(timeTable, Start.consoleWidth-20).Centered()).Width(Start.consoleWidth);
-            AnsiConsole.Write(mainTable);            
 
-            //var debug = new Table();
-            //debug.AddColumn("Debug");
-            //debug.AddRow("lastseconds" + Start.prevMusicTimePlayed);
-            //AnsiConsole.Write(debug);
+            //NOTE(ra) Tested Live draw routine. Left this here for now if it gets used in the future.
+
+            /* AnsiConsole.Live(mainTable) */
+            /*     .AutoClear(false) */
+            /*     .Start(async ctx => */
+            /*             { */
+            /*                 ctx.Refresh(); */
+            /*             }); */
+            AnsiConsole.Write(mainTable);            
         }
         catch (Exception e) {
             AnsiConsole.Clear();
@@ -512,7 +518,8 @@ static class TUI
     }
 
     public static void RehreshCurrentView() {
-        AnsiConsole.Clear();
+        //NOTE(ra) This Clear() caused flickering.
+        /* AnsiConsole.Clear(); */
         if (Start.playerView == "default") {
             DrawPlayer();
         }

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -1,9 +1,7 @@
-using ManagedBass;
-using System;
-using System.IO;
-using System.Text.RegularExpressions;
-
-
+/* using ManagedBass; */
+/* using System; */
+/* using System.IO; */
+/* using System.Text.RegularExpressions; */
 
 namespace jammer
 {


### PR DESCRIPTION
Removed Clear() which caused terminal window to flicker.

When music is playing screen is not cleared. Only if terminal window
size is changed.
