### PR TITLE
refactor: Added utility method for calculating directory size

### DIFF
--- a/src/Preferences.cs
+++ b/src/Preferences.cs
@@ -236,6 +236,27 @@ namespace jammer
             }
         }
 
+	public static long DirSize(DirectoryInfo d)
+	{
+
+	    long size = 0;
+	    // Add file sizes.
+	    FileInfo[] fis = d.GetFiles();
+	    foreach (FileInfo fi in fis) {
+	        size += fi.Length;
+	    }
+	    // Add subdirectory sizes.
+	    DirectoryInfo[] dis = d.GetDirectories();
+	    foreach (DirectoryInfo di in dis) {
+	        size += DirSize(di);
+	    }
+	    return size;
+	}
+
+        public static double ToKilobytes(long bytes) => bytes / 1024d;
+        public static double ToMegabytes(long bytes) => ToKilobytes(bytes) / 1024d;
+        public static double ToGigabytes(long bytes) => ToMegabytes(bytes) / 1024d;
+
         public class Settings
         {
             public bool IsLoop { get; set; }
@@ -248,7 +269,6 @@ namespace jammer
             public bool isShuffle { get; set; }
             public bool isAutoSave { get; set; }
             public string? localeLanguage { get; set; }
-            
         }
     }
 }

--- a/src/Start.cs
+++ b/src/Start.cs
@@ -55,9 +55,18 @@ namespace jammer
                         case "-D":
                             Utils.isDebug = true;
                             Debug.dprint("\n--- Debug Started ---\n");
+
+                            long size = Preferences.DirSize(new DirectoryInfo(Utils.jammerPath));
+                            Debug.dprint($"JammerDirSize: {size}");
+                            Debug.dprint($"JammerDirSize: {Preferences.ToKilobytes(size)}");
+                            Debug.dprint($"JammerDirSize: {Preferences.ToMegabytes(size)}");
+                            Debug.dprint($"JammerDirSize: {Preferences.ToGigabytes(size)}");
+
                             List<string> argumentsList = new List<string>(args);
                             argumentsList.RemoveAt(i);
                             args = argumentsList.ToArray();
+                            //NOTES(ra) So nasty it breaks my hearth,
+                            Utils.songs = args;
                             break;
                     }
                 }


### PR DESCRIPTION
This commit adds a new static method 'DirSize' to the 'Preferences' class, which recursively calculates and returns the total size of a given directory in bytes. The method also includes helper methods for converting byte sizes to kilobytes, megabytes, and gigabytes. The addition of this utility method improves the readability and maintainability of the codebase by encapsulating this functionality within the 'Preferences' class, which is already responsible for managing user preferences.

Functions
- DirSize
- ToKilobytes
- ToMegabytes
- ToGigabytes
