### PR TITLE
Fixed breaking exception with Debug arg

### DIFF
--- a/Jammer.Core/src/Args.cs
+++ b/Jammer.Core/src/Args.cs
@@ -22,12 +22,20 @@ namespace Jammer
                             Debug.dprint(APPDIRlen.Length.ToString());
                         }
 
-                        long size = Preferences.DirSize(new System.IO.DirectoryInfo(Utils.JammerPath));
-                        Debug.dprint($"JammerDirSize: {size}");
-                        Debug.dprint($"JammerDirSize: {Preferences.ToKilobytes(size)}");
-                        Debug.dprint($"JammerDirSize: {Preferences.ToMegabytes(size)}");
-                        Debug.dprint($"JammerDirSize: {Preferences.ToGigabytes(size)}");
-
+                        try {
+                            long size = Preferences.DirSize(new System.IO.DirectoryInfo(Utils.JammerPath));
+                            Debug.dprint($"JammerDirSize: {size}");
+                            Debug.dprint($"JammerDirSize: {Preferences.ToKilobytes(size)}");
+                            Debug.dprint($"JammerDirSize: {Preferences.ToMegabytes(size)}");
+                            Debug.dprint($"JammerDirSize: {Preferences.ToGigabytes(size)}");
+                        }
+                        catch (DirectoryNotFoundException e) {
+                            Debug.dprint("Error in DirSize, folder doesnt exist yet.");
+                            Debug.dprint(e.Message);
+                        }
+                        catch (System.Exception) {
+                            Debug.dprint("Error in DirSize");
+                        }
                         List<string> argumentsList = new List<string>(args);
                         argumentsList.RemoveAt(i);
                         args = argumentsList.ToArray();


### PR DESCRIPTION
If the -D Debug arg is present and the default folder for jammer doesnt exist the application will throw an uncaught exception. This fix will catch the exception and add it to the debug output.

how to reproduce on linux:

mv ~/jammer ~/jammer_bak
jammer -D
🔥 🔥 🔥 
