### PR TITLE
[Feature]: give options to customize jammerPath

### DIFF
--- a/Jammer.Core/src/Themes.cs
+++ b/Jammer.Core/src/Themes.cs
@@ -148,7 +148,7 @@ namespace Jammer {
 }";
 
         public static Theme? CurrentTheme { get; private set; }
-        static string themePath = Path.Combine(Utils.JammerPath, "themes");
+        static readonly string themePath = Path.Combine(Utils.JammerPath, "themes");
         public static void Init() {
             int returne = 0;
             if (Preferences.GetTheme() == null || Preferences.GetTheme() == "" || Preferences.GetTheme() == "Jammer Default") {

--- a/Jammer.Core/src/Utils.cs
+++ b/Jammer.Core/src/Utils.cs
@@ -38,12 +38,32 @@ namespace Jammer
         public static string urlPatternHTTPS = @"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)";
         public static string urlPatternHTTP = @"http?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)";
         public static bool mainLoop = true;
-        public static string JammerPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "jammer");
+        public static string JammerPath = UtilFuncs.GetJammerPath();
         public static bool isDebug = false;
         public static string currentPlaylist = "";
         public static bool isInitialized = false;
         public static string version = "2.12.4.4";
         public static string? AppDirMount = Environment.GetEnvironmentVariable("APPDIR");
         public static float MusicTimePercentage = 0;
+    }
+
+    // Class to hold Util related Functions
+    public class UtilFuncs {
+        // Return user preferred path for JammerPath
+        public static string GetJammerPath() {
+            string defaultJammerFolderName = "jammer";
+            // use xdg_config_home if it is set
+            if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("XDG_CONFIG_HOME"))) {
+                return Path.Combine(Environment.GetEnvironmentVariable("XDG_CONFIG_HOME"), defaultJammerFolderName);
+            }
+
+            // use JAMMER_CONFIG_PATH if it is set
+            if (!String.IsNullOrEmpty(Environment.GetEnvironmentVariable("JAMMER_CONFIG_PATH"))) {
+                return Environment.GetEnvironmentVariable("JAMMER_CONFIG_PATH");
+            }
+
+            // use the default user profile path
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), defaultJammerFolderName);
+        }
     }
 }

--- a/Jammer.Core/src/Utils.cs
+++ b/Jammer.Core/src/Utils.cs
@@ -48,7 +48,7 @@ namespace Jammer
     }
 
     // Class to hold Util related Functions
-    public class UtilFuncs {
+    public static class UtilFuncs {
         // Return user preferred path for JammerPath
         public static string GetJammerPath() {
             string defaultJammerFolderName = "jammer";


### PR DESCRIPTION
As of now the jammerPath is hardcoded to '~/jammer'. If you wish to keep your userProfile folder clean its sometimes prefered to manually adjust where stuff is stored. 
This feature will utilize either  
-the environment variable XDG_CONFIG_HOME with the default Jammer folder name if its present  
-the environment variable JAMMER_CONFIG_PATH without the default Jammer folder name if its present 
-the original default behaviour as last fallback, ~/ + the default Jammer folder name.

with this change new options can easily be added in the future.
@todo: fix readme if this request is merged to reflect the new options.