### PR TITLE
feat(build): add submodule initialization to build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ export LD_LIBRARY_PATH=/path/to/your/library:$LD_LIBRARY_PATH
 
 On **Windows**, you need to add the libraries to the executable folder.
 
+## Install submodules
+
+Jammer uses git submodules. To get the submodules, run this command in the root folder. 
+
+```bash
+git submodule update --init --recursive
+```
+
 ### Run
 
 ```bash

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+check_and_install_submodules() {
+    if [ ! -d .git ]; then
+        echo "This is not a git repository."
+        exit 1
+    fi
+
+    if [ ! -f .gitmodules ]; then
+        echo "No submodules found in this repository."
+        return
+    fi
+
+    if git submodule status | grep -q '^[-+]'; then
+        echo "Initializing and updating submodules..."
+        git submodule update --init --recursive
+    else
+        echo "All submodules are up to date."
+    fi
+}
+

--- a/scripts/debug-build.sh
+++ b/scripts/debug-build.sh
@@ -7,8 +7,8 @@ check_and_install_submodules
 
 cd "$(dirname "$0")/.."
 
-if [ -f jammer-*.AppImage ]; then
-    rm jammer-*.AppImage
+if [ -f jammer-*-debug.AppImage ]; then
+    rm jammer-*-debug.AppImage
 fi
 
 if [ -f jammer.AppDir/user/bin/Jammer ]; then
@@ -29,12 +29,13 @@ if [[ ! $LD_LIBRARY_PATH == *"../libs/linux/x86_64"* ]]; then
     # Return to the previous directory
     cd -
 fi
-dotnet publish -r linux-x64 -c Release /p:PublishSingleFile=true
+# Build with debug symbols enabled
+dotnet publish -r linux-x64 -c Debug /p:PublishSingleFile=true /p:DebugType=full /p:DebugSymbols=true
 cd ..
 
 mkdir -p jammer.AppDir/usr/{bin,lib,locales}
-cp -v Jammer.CLI/bin/Release/net8.0/linux-x64/publish/Jammer.CLI jammer.AppDir/usr/bin/Jammer
-cp -v Jammer.CLI/bin/Release/net8.0/linux-x64/publish/libuiohook.so jammer.AppDir/usr/lib/libuiohook.so
+cp -v Jammer.CLI/bin/Debug/net8.0/linux-x64/publish/Jammer.CLI jammer.AppDir/usr/bin/Jammer
+cp -v Jammer.CLI/bin/Debug/net8.0/linux-x64/publish/libuiohook.so jammer.AppDir/usr/lib/libuiohook.so
 cp -v libs/linux/x86_64/libbass* jammer.AppDir/usr/lib
 cp -v locales/* jammer.AppDir/usr/locales
 
@@ -43,6 +44,6 @@ if [ ! -f ./appimagetool-x86_64.AppImage ]; then
         chmod 700 ./appimagetool-x86_64.AppImage
 fi
 
-ARCH=x86_64 ./appimagetool-x86_64.AppImage jammer.AppDir jammer-$(cat VERSION)-x86_64.AppImage
+ARCH=x86_64 ./appimagetool-x86_64.AppImage jammer.AppDir jammer-$(cat VERSION)-debug-x86_64.AppImage
 
-#./jammer-$(cat VERSION)-x86_64.AppImage 
+#./jammer-$(cat VERSION)-debug-x86_64.AppImage 


### PR DESCRIPTION
- Updated `README.md` with instructions to install submodules.
- Added `check_and_install_submodules` function in `common.sh`.
- Modified `build.sh` and `debug-build.sh` to source `common.sh` and ensure submodules are initialized and updated.
- Enhanced `debug-build.sh` to include debug-specific build steps.

This ensures submodules are properly initialized and updated during build processes, improving developer experience and build reliability.