### PR TITLE
feat(keybindings): VIM-style preset and navigation support

### DIFF
--- a/Jammer.Core/src/Keyboard.cs
+++ b/Jammer.Core/src/Keyboard.cs
@@ -247,14 +247,31 @@ namespace Jammer
                         drawWhole = true;
                         Action = ""; // Clear action
                     }
+                    else if (Action == "PlaylistViewScrolldown" || Action == "NextSong")
+                    {
+                        HelpMenuComponent.NextHelpPage();
+                        drawWhole = true;
+                        Action = ""; // Clear action
+                    }
+                    else if (Action == "PlaylistViewScrollup" || Action == "PreviousSong")
+                    {
+                        HelpMenuComponent.PreviousHelpPage();
+                        drawWhole = true;
+                        Action = ""; // Clear action
+                    }
                     else if (Action == "ToMainMenu" || Action == "Help")
                     {
                         playerView = "default";
                         drawWhole = true;
                         Action = ""; // Clear action
                     }
+                    else
+                    {
+                        // Swallow all other actions while in help view
+                        Action = "";
+                    }
                 }
-                if (playerView.Equals("settings"))
+                else if (playerView.Equals("settings"))
                 {
                     // Handle settings page navigation first
                     if (key.Key == ConsoleKey.PageDown || key.Key == ConsoleKey.RightArrow)
@@ -264,6 +281,18 @@ namespace Jammer
                         Action = ""; // Clear action
                     }
                     else if (key.Key == ConsoleKey.PageUp || key.Key == ConsoleKey.LeftArrow)
+                    {
+                        SettingsComponent.PreviousSettingsPage();
+                        drawWhole = true;
+                        Action = ""; // Clear action
+                    }
+                    else if (Action == "PlaylistViewScrolldown" || Action == "NextSong")
+                    {
+                        SettingsComponent.NextSettingsPage();
+                        drawWhole = true;
+                        Action = ""; // Clear action
+                    }
+                    else if (Action == "PlaylistViewScrollup" || Action == "PreviousSong")
                     {
                         SettingsComponent.PreviousSettingsPage();
                         drawWhole = true;

--- a/KeyData_vim.ini
+++ b/KeyData_vim.ini
@@ -1,0 +1,56 @@
+; VIM-style preset for Jammer
+; Copy this to your Jammer config as KeyData.ini to enable.
+; IMPORTANT: For single-letter keys, use UPPERCASE letters.
+; ConsoleKey uses uppercase names (A..Z); the matcher is case-sensitive.
+; See Jammer.Core/src/IniFileHandling.cs for supported keys and modifiers.
+
+[Keybinds]
+ToMainMenu = Escape
+PlayPause = P
+Quit = Q
+NextSong = N
+PreviousSong = Shift + N
+PlaySong = Enter
+Forward5s = L
+Backwards5s = H
+VolumeUp = Shift + K
+VolumeDown = Shift + J
+VolumeUpByOne = Ctrl + K
+VolumeDownByOne = Ctrl + J
+Shuffle = Z
+SaveAsPlaylist = Shift + W
+SaveCurrentPlaylist = W
+ShufflePlaylist = Alt + Z
+Loop = R
+Mute = M
+ShowHidePlaylist = T
+ListAllPlaylists = Shift + P
+ChangeTheme = Shift + T
+Help = F1
+Settings = S
+ToSongStart = 0
+ToSongEnd = Shift + G
+ToggleInfo = I
+SearchInPlaylist = F
+SearchByAuthor = Shift + F
+CurrentState = F12
+CommandHelpScreen = Tab
+DeleteCurrentSong = D
+AddSongToPlaylist = A
+ShowSongsInPlaylists = Shift + A
+PlayOtherPlaylist = O
+RedownloadCurrentSong = Shift + B
+EditKeybindings = E
+ChangeLanguage = Shift + L
+ChangeSoundFont = G
+PlayRandomSong = Shift + R
+PlaylistViewScrollup = K
+PlaylistViewScrolldown = J
+Choose = Enter
+AddSongToQueue = Y
+Search = Ctrl + Y
+ShowLog = Ctrl + L
+HardDeleteCurrentSong = Shift + D
+RenameSong = C
+ExitRssFeed = Q
+BackEndChange = B

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ for the playlist feature across different platforms***
 - [Developing](#developing)
 - [Build / Run yourself](#build--run-yourself)
 - [Known Issues](#known-issues)
+ - [Keybindings](#keybindings)
 
 ## Install/Update
 
@@ -153,6 +154,17 @@ These can be changed in the Effects.ini file in the jammer folder.
 
 - **Windows**: `C:\Users\username\jammer`
 - **Linux**: `~/jammer`
+
+## Keybindings
+
+- Defaults are built-in. To customize, create `KeyData.ini` in your Jammer config folder (see paths above). The app reads keys from `[Keybinds]` in that file.
+- A VIM-style preset is shipped as `KeyData_vim.ini`:
+  - Windows installer copies it to `C:\Users\username\jammer\KeyData_vim.ini`.
+  - AppImage copies it on first run to `~/jammer/KeyData_vim.ini` (or `$JAMMER_CONFIG_PATH/KeyData_vim.ini`).
+  - To enable, copy or rename it to `KeyData.ini` in the same folder.
+- Notes:
+  - Single-letter keys must be uppercase (e.g., `N`, `P`, `J`, `K`). Modifiers are `Shift`, `Ctrl`, `Alt`.
+  - Help/Settings page navigation also respects actions `PlaylistViewScrolldown`/`PlaylistViewScrollup` and `NextSong`/`PreviousSong`.
 
 ### Environment Variables
 

--- a/jammer.AppDir/AppRun
+++ b/jammer.AppDir/AppRun
@@ -1,14 +1,19 @@
 #!/bin/bash
 # Add after the first line and before the exports
 
-# Set default config path if JAMMER_CONFIG_PATH is not set
-TARGET_PATH="${JAMMER_CONFIG_PATH:-$HOME/jammer}/locales"
+# Set default config root if JAMMER_CONFIG_PATH is not set
+CONFIG_ROOT="${JAMMER_CONFIG_PATH:-$HOME/jammer}"
 
-# Create target directory
-mkdir -p "$TARGET_PATH"
+# Ensure config directories exist
+mkdir -p "$CONFIG_ROOT/locales"
 
 # Copy locale files
-cp -rf "$APPDIR/usr/locales/"* "$TARGET_PATH/"
+cp -rf "$APPDIR/usr/locales/"* "$CONFIG_ROOT/locales/"
+
+# Copy VIM preset without overwriting existing file
+if [ -f "$APPDIR/usr/KeyData_vim.ini" ]; then
+  cp -n "$APPDIR/usr/KeyData_vim.ini" "$CONFIG_ROOT/KeyData_vim.ini" 2>/dev/null || true
+fi
 
 export LD_LIBRARY_PATH=$APPDIR/usr/lib
 exec $APPDIR/usr/bin/Jammer "$@"

--- a/nsis/setup.nsi
+++ b/nsis/setup.nsi
@@ -102,6 +102,11 @@ SetOutPath $PROFILE\Jammer\docs
 File /r "docs\*.*"
 SetOutPath $INSTALL_DIR
 
+; Copy optional VIM keybind preset to user config root
+CreateDirectory $PROFILE\Jammer
+SetOutPath $PROFILE\Jammer
+File "KeyData_vim.ini"
+
 SectionEnd
 
 ############# SETUP ################

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,6 +37,7 @@ cp -v Jammer.CLI/bin/Release/net8.0/linux-x64/publish/Jammer.CLI jammer.AppDir/u
 cp -v Jammer.CLI/bin/Release/net8.0/linux-x64/publish/libuiohook.so jammer.AppDir/usr/lib/libuiohook.so
 cp -v libs/linux/x86_64/libbass* jammer.AppDir/usr/lib
 cp -v locales/* jammer.AppDir/usr/locales
+cp -v KeyData_vim.ini jammer.AppDir/usr/KeyData_vim.ini
 
 if [ ! -f ./appimagetool-x86_64.AppImage ]; then
         curl -LO https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage

--- a/scripts/debug-build.sh
+++ b/scripts/debug-build.sh
@@ -38,6 +38,7 @@ cp -v Jammer.CLI/bin/Debug/net8.0/linux-x64/publish/Jammer.CLI jammer.AppDir/usr
 cp -v Jammer.CLI/bin/Debug/net8.0/linux-x64/publish/libuiohook.so jammer.AppDir/usr/lib/libuiohook.so
 cp -v libs/linux/x86_64/libbass* jammer.AppDir/usr/lib
 cp -v locales/* jammer.AppDir/usr/locales
+cp -v KeyData_vim.ini jammer.AppDir/usr/KeyData_vim.ini
 
 if [ ! -f ./appimagetool-x86_64.AppImage ]; then
         curl -LO https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage


### PR DESCRIPTION
- Introduced `KeyData_vim.ini` as a VIM-style keybinding preset.
- Updated `Keyboard.cs` to support `PlaylistViewScrollup`/`Scrolldown` and `NextSong`/`PreviousSong` actions for Help and Settings views.
- Enhanced `README.md` with instructions for enabling the VIM preset.
- Modified `AppRun` to copy the VIM preset on first run.
- Updated NSIS installer to include the VIM preset in user config.
- Adjusted build scripts to package the VIM preset.

This change improves user customization and navigation consistency.