### PR TITLE
fix: properly dispose TagLib.File resources with using statements

### DIFF
--- a/Jammer.Core/src/Download.cs
+++ b/Jammer.Core/src/Download.cs
@@ -690,16 +690,25 @@ namespace Jammer
 
                         try
                         {
-                            var file = TagLib.File.Create(songPath);
-                            file.Tag.Title = Start.Sanitize(track.Title);
-                            file.Tag.Description = track.Description;
-                            if (track.User != null && track.User.Username != null)
+                            using (var file = TagLib.File.Create(songPath))
                             {
-                                file.Tag.Performers = new string[] { track.User.Username };
+                                file.Tag.Title = Start.Sanitize(track.Title);
+                                file.Tag.Description = track.Description;
+                                if (track.User != null && track.User.Username != null)
+                                {
+                                    file.Tag.Performers = new string[] { track.User.Username };
+                                }
+                                file.Save();
                             }
-                            file.Save();
                             if (track.ArtworkUrl != null)
                                 await DownloadThumbnailAsync(track.ArtworkUrl, songPath);
+
+                            constructedSong = new Song
+                            {
+                                URI = url,
+                                Title = track.Title,
+                                Author = track.User?.Username ?? null
+                            };
                         }
                         catch (Exception ex)
                         {
@@ -754,7 +763,7 @@ namespace Jammer
 
         static async Task DownloadThumbnailAsync(Uri imageUrl, string songPath)
         {
-            var file = TagLib.File.Create(songPath);
+            using var file = TagLib.File.Create(songPath);
             using WebClient webClient = new();
             byte[] imageBytes = webClient.DownloadData(imageUrl);
             Picture picture = new(imageBytes);

--- a/Jammer.Core/src/Play.cs
+++ b/Jammer.Core/src/Play.cs
@@ -236,12 +236,14 @@ namespace Jammer
 
                 try
                 {
-                    tagFile = TagLib.File.Create(fullPathToFile);
-                    title = tagFile.Tag.Title;
-                    author = tagFile.Tag.FirstPerformer;
-                    album = tagFile.Tag.Album;
-                    year = tagFile.Tag.Year.ToString();
-                    genre = tagFile.Tag.FirstGenre;
+                    using (tagFile = TagLib.File.Create(fullPathToFile))
+                    {
+                        title = tagFile.Tag.Title;
+                        author = tagFile.Tag.FirstPerformer;
+                        album = tagFile.Tag.Album;
+                        year = tagFile.Tag.Year.ToString();
+                        genre = tagFile.Tag.FirstGenre;
+                    }
                 }
                 catch (Exception)
                 {
@@ -253,17 +255,17 @@ namespace Jammer
             // Message.Data(SongExtensions.ToSongString(song), "22");
 
             // append title to song
-            if (song.Title == null || song.Title == "")
+            if ((song.Title == null || song.Title == "") && !string.IsNullOrEmpty(title))
             {
                 // Log.Info("______trying to get it from the path");
                 // Message.Data(SongExtensions.ToSongString(song), "55" + title);
                 song.Title = title;
             }
-            if (song.Author == null || song.Author == "")
+            if ((song.Author == null || song.Author == "") && !string.IsNullOrEmpty(author))
             {
                 song.Author = author;
             }
-            if (song.Album == null || song.Album == "")
+            if ((song.Album == null || song.Album == "") && !string.IsNullOrEmpty(album))
             {
                 song.Album = album;
             }
@@ -275,7 +277,7 @@ namespace Jammer
                 }
                 song.Year = year;
             }
-            if (song.Genre == null || song.Genre == "")
+            if ((song.Genre == null || song.Genre == "") && !string.IsNullOrEmpty(genre))
             {
                 song.Genre = genre;
             }


### PR DESCRIPTION
- Wrap TagLib.File.Create() calls in using statements to ensure proper resource disposal in Download.cs and Play.cs
- Add null checks before assigning tag metadata to prevent overwriting valid song properties with empty values
- Create Song object after metadata is written in Download.cs