### PR TITLE
refactor: replace loop threads with RenderLoop

### DIFF
--- a/Jammer.Core/src/RenderLoop.cs
+++ b/Jammer.Core/src/RenderLoop.cs
@@ -1,0 +1,228 @@
+using ManagedBass;
+using Spectre.Console;
+
+namespace Jammer
+{
+    /// <summary>
+    /// Single-threaded render loop driven by a PeriodicTimer at 30 Hz (33ms).
+    ///
+    /// Replaces the two previous threads:
+    ///   - Start.Loop()          (was Thread.Sleep(1)  = ~1000 Hz)
+    ///   - Start.EqualizerLoop() (was while(true) with no exit, ~100 Hz)
+    ///
+    /// Tick schedule:
+    ///   Every tick  (30 Hz)  : visualizer redraw if enabled + in player view
+    ///   Every 3rd   (10 Hz)  : BASS position query, playback state machine, time bar
+    ///   Every 30th  (1 Hz)   : console resize check
+    ///   On dirty flag        : full DrawPlayer() rebuild
+    /// </summary>
+    public static class RenderLoop
+    {
+        private static CancellationTokenSource _cts = new();
+        private static Task _task = Task.CompletedTask;
+
+        // Tick counters
+        private const int TickIntervalMs = 33;   // ~30 Hz
+        private const int PlaybackTickInterval = 3;   // every 3rd tick  = ~10 Hz
+        private const int ResizeTickInterval = 30;  // every 30th tick = ~1 Hz
+
+        public static void Start()
+        {
+            _cts = new CancellationTokenSource();
+            _task = Task.Run(() => RunAsync(_cts.Token));
+        }
+
+        public static void Stop()
+        {
+            _cts.Cancel();
+            // Wait briefly for the loop to exit cleanly
+            try { _task.Wait(500); } catch { }
+        }
+
+        private static async Task RunAsync(CancellationToken ct)
+        {
+            // One-time initialisation (mirrors what Loop() did on first entry)
+            Jammer.Start.lastSeconds = -1;
+            Jammer.Start.treshhold = 1;
+            Utils.IsInitialized = true;
+
+            AnsiConsole.Clear();
+            TUI.RefreshCurrentView();
+            AnsiConsole.Cursor.Hide();
+
+            var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(TickIntervalMs));
+            int tick = 0;
+
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    await timer.WaitForNextTickAsync(ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                tick++;
+                AnsiConsole.Cursor.Hide();
+
+                // ── 1 Hz: console resize ──────────────────────────────────────
+                if (tick % ResizeTickInterval == 0)
+                {
+                    int w = Console.WindowWidth;
+                    int h = Console.WindowHeight;
+                    if (w != Jammer.Start.consoleWidth || h != Jammer.Start.consoleHeight)
+                    {
+                        Jammer.Start.consoleWidth = w;
+                        Jammer.Start.consoleHeight = h;
+                        AnsiConsole.Clear();
+                        RenderState.NeedsFullRedraw = true;
+                    }
+                }
+
+                // ── 10 Hz: playback state machine + BASS queries ──────────────
+                if (tick % PlaybackTickInterval == 0)
+                {
+                    TickPlayback();
+                }
+
+                // ── 30 Hz: visualizer ─────────────────────────────────────────
+                string view = Jammer.Start.playerView;
+                bool inPlayerView = view == "default" || view == "all" || view == "rss";
+
+                if (inPlayerView && Preferences.isVisualizer)
+                {
+                    var s = Jammer.Start.state;
+                    if (s == MainStates.playing || s == MainStates.pause ||
+                        s == MainStates.stop    || s == MainStates.idle)
+                    {
+                        TUI.DrawVisualizer();
+                    }
+                }
+
+                // ── Dirty flags: time bar and full redraw ─────────────────────
+                if (RenderState.NeedsTimeRedraw)
+                {
+                    RenderState.NeedsTimeRedraw = false;
+                    TUI.DrawTime();
+                }
+
+                if (RenderState.NeedsFullRedraw || Jammer.Start.previousView != view)
+                {
+                    RenderState.NeedsFullRedraw = false;
+                    Jammer.Start.previousView = view;
+                    TUI.RefreshCurrentView();
+                }
+
+                // ── Keyboard (non-blocking) ───────────────────────────────────
+                // Only check when loop is in a state that expects input
+                if (Jammer.Start.state == MainStates.idle ||
+                    Jammer.Start.state == MainStates.playing)
+                {
+                    await Jammer.Start.CheckKeyboardAsync();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Playback state machine + BASS position update.
+        /// Runs at 10 Hz. Mirrors the logic from Start.Loop().
+        /// </summary>
+        private static void TickPlayback()
+        {
+            // Handle pending song queue entry (first slot empty = more songs queued)
+            if (Utils.Songs.Length != 0)
+            {
+                if (Utils.Songs[0] == "" && Utils.Songs.Length > 1)
+                {
+                    Jammer.Start.state = MainStates.play;
+                    Play.DeleteSong(0, false);
+                    Play.PlaySong();
+                }
+            }
+
+            switch (Jammer.Start.state)
+            {
+                case MainStates.play:
+                    if (Utils.Songs.Length > 0)
+                    {
+                        Play.PlaySong();
+                        TUI.ClearScreen();
+                        TUI.DrawPlayer();
+                        Utils.TotalMusicDurationInSec = 0;
+                        Jammer.Start.state = MainStates.playing;
+                    }
+                    else
+                    {
+                        RenderState.NeedsFullRedraw = true;
+                        Jammer.Start.state = MainStates.idle;
+                    }
+                    break;
+
+                case MainStates.playing:
+                    // Update time bar once per second of playback
+                    if (Utils.TotalMusicDurationInSec - Jammer.Start.prevMusicTimePlayed >= 1)
+                    {
+                        RenderState.NeedsTimeRedraw = true;
+                        Jammer.Start.prevMusicTimePlayed = Utils.TotalMusicDurationInSec;
+                    }
+
+                    // Song finished
+                    if (Bass.ChannelIsActive(Utils.CurrentMusic) == PlaybackState.Stopped
+                        && Utils.TotalMusicDurationInSec > 0)
+                    {
+                        Jammer.Start.prevMusicTimePlayed = 0;
+                        RenderState.NeedsTimeRedraw = true;
+                    }
+
+                    // RSS auto-skip
+                    if (Play.ShouldSkipRss())
+                    {
+                        Play.MaybeNextSong(forceNoLoop: true);
+                    }
+                    break;
+
+                case MainStates.pause:
+                    Play.PauseSong();
+                    Jammer.Start.state = MainStates.idle;
+                    break;
+
+                case MainStates.stop:
+                    Play.StopSong();
+                    Jammer.Start.state = MainStates.idle;
+                    break;
+
+                case MainStates.next:
+                    Play.NextSong();
+                    break;
+
+                case MainStates.previous:
+                    if (Utils.TotalMusicDurationInSec > 3)
+                    {
+                        Play.SeekSong(0, false);
+                        Jammer.Start.state = MainStates.playing;
+                    }
+                    else
+                    {
+                        Play.PrevSong();
+                    }
+                    break;
+            }
+
+            // Update BASS position values (was done every tick in the old loop)
+            Utils.PreciseTime = Bass.ChannelBytes2Seconds(
+                Utils.CurrentMusic, Bass.ChannelGetPosition(Utils.CurrentMusic));
+            Utils.TotalMusicDurationInSec = Utils.PreciseTime;
+            Utils.SongDurationInSec = Bass.ChannelBytes2Seconds(
+                Utils.CurrentMusic, Bass.ChannelGetLength(Utils.CurrentMusic));
+            Utils.MusicTimePercentage = (float)(
+                Utils.TotalMusicDurationInSec / Utils.SongDurationInSec * 100);
+
+            if (Utils.Songs.Length == 0)
+            {
+                Utils.CurrentSongPath = "";
+            }
+        }
+    }
+}

--- a/Jammer.Core/src/RenderState.cs
+++ b/Jammer.Core/src/RenderState.cs
@@ -1,0 +1,15 @@
+namespace Jammer
+{
+    /// <summary>
+    /// Thread-safe render dirty flags. Set by keyboard/state handlers,
+    /// consumed and cleared by RenderLoop on each tick.
+    /// </summary>
+    public static class RenderState
+    {
+        /// <summary>Full player view rebuild needed (view switch, song change, resize, etc.)</summary>
+        public static volatile bool NeedsFullRedraw = false;
+
+        /// <summary>Time bar / progress bar redraw needed (playback position changed).</summary>
+        public static volatile bool NeedsTimeRedraw = false;
+    }
+}

--- a/Jammer.Core/src/Start.cs
+++ b/Jammer.Core/src/Start.cs
@@ -33,8 +33,6 @@ namespace Jammer
         // public static MainStates state = MainStates.idle;
         // ! Translations needed to locales
         public static MainStates state = MainStates.playing;
-        private static Thread loopThread = new(() => { });
-        private static Thread visualizerThread = new(() => { });
         public static int consoleWidth = Console.WindowWidth;
         public static int consoleHeight = Console.WindowHeight;
         public static bool CLI = false;
@@ -42,7 +40,6 @@ namespace Jammer
         public static double lastPlaybackTime = -1;
         public static double treshhold = 1;
         public static double prevMusicTimePlayed = 0;
-        public static bool LoopRunning = true;
 
         //
         // Run
@@ -123,228 +120,30 @@ namespace Jammer
             Console.CancelKeyPress += new ConsoleCancelEventHandler(Exit.OnExit);
             AppDomain.CurrentDomain.ProcessExit += new EventHandler(Exit.OnProcessExit);
 
-            Debug.dprint("Start Loop");
-            loopThread = new Thread(Loop);
-            visualizerThread = new Thread(EqualizerLoop);
-            loopThread.Start();
-            visualizerThread.Start();
+            Debug.dprint("Start RenderLoop");
+            RenderLoop.Start();
         }
 
         //
-        // Main loop
+        // Render dirty flags — set by keyboard/state handlers, consumed by RenderLoop.
+        // Keep these as pass-through properties pointing to RenderState for
+        // backwards compatibility with any callers not yet migrated.
         //
-        public static bool drawTime = false;
-        public static bool drawVisualizer = false;
-        public static bool drawWhole = false;
+        public static bool drawTime
+        {
+            get => RenderState.NeedsTimeRedraw;
+            set => RenderState.NeedsTimeRedraw = value;
+        }
+        public static bool drawWhole
+        {
+            get => RenderState.NeedsFullRedraw;
+            set => RenderState.NeedsFullRedraw = value;
+        }
+        // drawVisualizer is no longer needed — visualizer runs every tick in RenderLoop.
+        public static bool drawVisualizer = false; // kept for source compatibility only
 
         public static string previousView = "default";
         public static bool debug = false;
-        public static void Loop()
-        {
-            lastSeconds = -1;
-            treshhold = 1;
-
-            Utils.IsInitialized = true;
-
-            AnsiConsole.Clear();
-            TUI.RefreshCurrentView();
-            AnsiConsole.Cursor.Hide();
-
-            while (LoopRunning)
-            {
-                AnsiConsole.Cursor.Hide();
-                if (Utils.Songs.Length != 0)
-                {
-                    // if the first song is "" then there are more songs
-                    if (Utils.Songs[0] == "" && Utils.Songs.Length > 1)
-                    {
-                        state = MainStates.play;
-                        Play.DeleteSong(0, false);
-                        Play.PlaySong();
-                    }
-                }
-
-                if (consoleWidth != Console.WindowWidth || consoleHeight != Console.WindowHeight)
-                {
-                    consoleHeight = Console.WindowHeight;
-                    consoleWidth = Console.WindowWidth;
-                    AnsiConsole.Clear();
-                    drawWhole = true;
-                }
-
-                switch (state)
-                {
-                    case MainStates.idle:
-                        // TUI.ClearScreen();
-                        _ = CheckKeyboardAsync();
-                        break;
-
-                    case MainStates.play:
-                        Debug.dprint("Play");
-                        if (Utils.Songs.Length > 0)
-                        {
-                            Debug.dprint("Play - len");
-                            Play.PlaySong();
-                            TUI.ClearScreen();
-                            TUI.DrawPlayer();
-
-                            Utils.TotalMusicDurationInSec = 0;
-                            state = MainStates.playing;
-                        }
-                        else
-                        {
-                            drawWhole = true;
-                            state = MainStates.idle;
-                        }
-                        break;
-
-                    case MainStates.playing:
-                        // every second, update screen, use MusicTimePlayed, and prevMusicTimePlayed
-                        if (Utils.TotalMusicDurationInSec - prevMusicTimePlayed >= 1)
-                        {
-                            drawTime = true;
-                            prevMusicTimePlayed = Utils.TotalMusicDurationInSec;
-                        }
-
-                        // If the song is finished
-                        if (Bass.ChannelIsActive(Utils.CurrentMusic) == PlaybackState.Stopped && Utils.TotalMusicDurationInSec > 0)
-                        {
-                            prevMusicTimePlayed = 0;
-                            drawTime = true;
-                        }
-
-                        // Check for RSS auto-skip timer
-                        if (Play.ShouldSkipRss())
-                        {
-                            Play.MaybeNextSong(forceNoLoop: true);
-                        }
-
-                        if (debug)
-                            Message.Data("asd", "asd");
-                        _ = CheckKeyboardAsync();
-                        break;
-
-                    case MainStates.pause:
-                        Play.PauseSong();
-                        state = MainStates.idle;
-                        break;
-
-                    case MainStates.stop:
-                        Play.StopSong();
-                        state = MainStates.idle;
-                        break;
-
-                    case MainStates.next:
-                        Debug.dprint("next");
-                        Play.NextSong();
-                        break;
-                    case MainStates.previous:
-                        if (Utils.TotalMusicDurationInSec > 3)
-                        { // if the song is played for more than 5 seconds, go to the beginning
-                            Play.SeekSong(0, false);
-                            state = MainStates.playing;
-                        }
-                        else
-                        {
-                            Play.PrevSong();
-                        }
-                        break;
-                }
-
-                if (debug)
-                    // print the call stack
-                    Message.Data(Environment.StackTrace, "Call Stack", true);
-
-                Utils.PreciseTime = Bass.ChannelBytes2Seconds(Utils.CurrentMusic, Bass.ChannelGetPosition(Utils.CurrentMusic));
-                // get current time in seconds
-                Utils.TotalMusicDurationInSec = Bass.ChannelBytes2Seconds(Utils.CurrentMusic, Bass.ChannelGetPosition(Utils.CurrentMusic));
-                // get whole song length in seconds
-                //Utils.currentMusicLength = Utils.audioStream.Length / Utils.audioStream.WaveFormat.AverageBytesPerSecond;
-                Utils.SongDurationInSec = Bass.ChannelBytes2Seconds(Utils.CurrentMusic, Bass.ChannelGetLength(Utils.CurrentMusic));
-
-                Utils.MusicTimePercentage = (float)(Utils.TotalMusicDurationInSec / Utils.SongDurationInSec * 100);
-
-                // if no song is playing, set the current song to ""
-                if (Utils.Songs.Length == 0)
-                {
-                    Utils.CurrentSongPath = "";
-                }
-
-                // If the view is changed, refresh the screen
-                if (previousView != playerView)
-                {
-                    drawWhole = true;
-                }
-
-                if (playerView == "default" || playerView == "all" || playerView == "rss")
-                {
-                    if (debug)
-                        Message.Data(drawWhole.ToString(), "22");
-
-                    if (drawVisualizer && Preferences.isVisualizer)
-                    {
-                        if (state == MainStates.playing || state == MainStates.pause || state == MainStates.stop || state == MainStates.idle)
-                        {
-                            TUI.DrawVisualizer();
-                        }
-                    }
-                    if (drawTime)
-                    {
-                        TUI.DrawTime();
-                    }
-                    if (drawWhole)
-                    {
-                        TUI.RefreshCurrentView();
-                    }
-                }
-                else
-                {
-                    if (drawWhole)
-                    {
-                        TUI.RefreshCurrentView();
-                    }
-                }
-
-                previousView = playerView;
-                drawVisualizer = false;
-                drawTime = false;
-                drawWhole = false;
-
-                if (playerView == "default" || playerView == "all" || playerView == "rss")
-                {
-                    Thread.Sleep(1);
-                }
-                else
-                    Thread.Sleep(5);
-            }
-        }
-
-        static bool canVisualize = false;
-        private static void EqualizerLoop()
-        {
-            while (true)
-            {
-                if (Preferences.isVisualizer)
-                {
-                    if (playerView == "default" || playerView == "all")
-                    {
-                        canVisualize = true;
-                    }
-                    else
-                    {
-                        canVisualize = false;
-                    }
-
-                    if (canVisualize)
-                    {
-                        drawVisualizer = true;
-                    }
-                }
-                Thread.Sleep(Visual.refreshTime);
-            }
-        }
-
-
         /// <summary>
         /// Removes "[" and "]" from a string to prevent Spectre.Console from blowing up.
         /// </summary>

--- a/Jammer.Core/src/Visual.cs
+++ b/Jammer.Core/src/Visual.cs
@@ -46,6 +46,11 @@ PausingEffect = true
         public static bool pausingEffect = true; // Pausing effect flag
 
         private static float scaleFactor = 1.0f;
+
+        // Reusable FFT buffer — allocated once, reused every frame to avoid GC pressure.
+        // Resized only when bufferSize changes.
+        private static float[] _fftBuffer = new float[41000];
+
         public static string GetSongVisual(int length, bool isPlaying)
         {
             // If the song is not playing, gradually decrease the scale factor
@@ -58,8 +63,12 @@ PausingEffect = true
                 scaleFactor = 1.0f; // Reset the scale factor when the song starts playing again
             }
 
-            int _bufferSize = bufferSize; // FFT data buffer size
-            var fftData = new float[_bufferSize]; // FFT data buffer
+            // Resize the reusable buffer only if the configured size has changed
+            if (_fftBuffer.Length != bufferSize)
+            {
+                _fftBuffer = new float[bufferSize];
+            }
+            var fftData = _fftBuffer; // Use the reusable buffer
 
             // Retrieve FFT data from current music channel
             int bytesRead = Bass.ChannelGetData(Utils.CurrentMusic, fftData, (int)GetFFTDataFlags());


### PR DESCRIPTION
Replace the two busy-wait threads (Loop at ~1000 Hz and EqualizerLoop at ~100 Hz) with a single async RenderLoop driven by a PeriodicTimer at 30 Hz.

- Add RenderLoop.cs: tick-based state machine at 30/10/1 Hz
- Add RenderState.cs: volatile dirty flags for redraws
- Remove loopThread, visualizerThread, LoopRunning from Start.cs
- Keep drawTime/drawWhole/drawVisualizer as shim properties for backwards compatibility
- Reuse FFT buffer in Visual.cs to reduce GC pressure